### PR TITLE
fix: add pull-requests: read permission to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      pull-requests: read
     with:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This changelog follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.
 
 ### Fixed
 
+- Added `pull-requests: read` permission to `publish.yml` so the reusable `cd.yml@ci-cd-workflows/v7` workflow can run.
 - Fixed ESLint flat config compatibility with `eslint-plugin-react-hooks@7` legacy plugins format.
 - Added `aria-label` to icon-only toolbar buttons for `@grafana/ui` 12.4.2 compatibility.
 - Replaced deprecated `classicColors` with `theme.visualization.palette`.


### PR DESCRIPTION
## Summary

- Adds `pull-requests: read` to the `cd` job's `permissions` block in `publish.yml`
- Fixes the workflow validation error: _"The workflow is requesting 'pull-requests: read', but is only allowed 'pull-requests: none'"_ from `cd.yml@ci-cd-workflows/v7`

## Test plan

- [ ] Re-run the publish workflow and confirm it passes the permissions validation step