### PR TITLE
fix: prepare plugin for React 19 compatibility

### DIFF
--- a/.config/.cprc.json
+++ b/.config/.cprc.json
@@ -1,3 +1,4 @@
 {
-  "version": "7.0.8"
+  "version": "7.6.0",
+  "features": {}
 }

--- a/.config/tsconfig.json
+++ b/.config/tsconfig.json
@@ -9,15 +9,18 @@
     "alwaysStrict": true,
     "declaration": false,
     "rootDir": "../src",
-    "baseUrl": "../src",
     "typeRoots": ["../node_modules/@types"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "paths": {
+      "*": ["../src/*"]
+    }
   },
   "ts-node": {
     "compilerOptions": {
-      "module": "commonjs",
-      "target": "es5",
-      "esModuleInterop": true
+      "module": "nodenext",
+      "target": "es2022",
+      "esModuleInterop": true,
+      "moduleResolution": "nodenext"
     },
     "transpileOnly": true
   },

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -83,7 +83,7 @@ jobs:
           fi
 
       - name: Coverage report
-        uses: davelosert/vitest-coverage-report-action@3c50566c523e04813df28de8f7c48dd97d663f1c # v2.11.2
+        uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2.12.0
         with:
           json-summary-path: coverage/coverage-summary.json
           json-summary-compare-path: ${{ steps.base-coverage.outputs.exists == 'true' && '/tmp/base-coverage/coverage-summary.json' || '' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
           export_env: false
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
           private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ This changelog follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.
 - Externalized `react/jsx-runtime` and `react/jsx-dev-runtime` for React 19 compatibility.
 - Removed deprecated `@types/testing-library__jest-dom` dev dependency.
 
+### CI/CD
+
+- Bumped `actions/create-github-app-token` v3.0.0 → v3.2.0.
+- Bumped `davelosert/vitest-coverage-report-action` v2.11.2 → v2.12.0.
+
 ### Known Issues
 
 - `react-big-calendar` bundles `react-overlays` which uses `ReactDOM.findDOMNode` (removed in React 19). The code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ This changelog follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `@grafana/create-plugin` scaffolding from 7.0.8 to 7.6.0 (fixes TypeScript 6 `baseUrl`/`bundler` compat).
+- Externalized `react/jsx-runtime` and `react/jsx-dev-runtime` for React 19 compatibility.
+- Removed deprecated `@types/testing-library__jest-dom` dev dependency.
+
+### Known Issues
+
+- `react-big-calendar` bundles `react-overlays` which uses `ReactDOM.findDOMNode` (removed in React 19). The code
+  path is only reached for class component instances and is unlikely to be hit in practice, but a permanent fix
+  requires an upstream release of `react-overlays` > 5.2.1.
+
 ### Project Updates
 
 - Added `.npmrc` with `ignore-scripts=true` to disable lifecycle scripts and mitigate supply-chain attack risk.

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -17,6 +17,7 @@
     "src/i18n/translations/**"
   ],
   "words": [
+    "davelosert",
     "datasource",
     "doesn",
     "dont",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-panel",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-panel",
-      "version": "4.2.3",
+      "version": "4.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.13.0",
@@ -34,7 +34,6 @@
         "@types/jest": "^29.5.14",
         "@types/node": "^24.1.0",
         "@types/react-big-calendar": "^1.16.2",
-        "@types/testing-library__jest-dom": "^5.14.9",
         "@types/webpack-env": "^1.18.8",
         "@volkovlabs/eslint-config": "^2.0.0",
         "@volkovlabs/jest-selectors": "^1.5.0",
@@ -5210,16 +5209,6 @@
       "resolved": "https://registry.npmjs.org/@types/systemjs/-/systemjs-6.15.3.tgz",
       "integrity": "sha512-STyj2LUevlyVqEQ1wjOORLQTJbNnM2V1DNzmemxVHlOovdKBKqccALDbR9aCcTRThhcXzew88SMbN4SMm6JOcw==",
       "license": "MIT"
-    },
-    "node_modules/@types/testing-library__jest-dom": {
-      "version": "5.14.9",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.9.tgz",
-      "integrity": "sha512-FSYhIjFlfOpGSRyVoMBMuS3ws5ehFQODymf3vlI7U1K8c7PHwWwFY7VREfmsuzHSOnoKs/9/Y983ayOs7eRzqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/jest": "*"
-      }
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^24.1.0",
     "@types/react-big-calendar": "^1.16.2",
-    "@types/testing-library__jest-dom": "^5.14.9",
     "@types/webpack-env": "^1.18.8",
     "@volkovlabs/eslint-config": "^2.0.0",
     "@volkovlabs/jest-selectors": "^1.5.0",


### PR DESCRIPTION
## Summary

Prepares the plugin to run on Grafana 13 (React 19) without breaking changes. Verified locally
against Grafana 13.1.0 (`dev-preview-react19`) — calendar renders correctly across all views
(Month, Week, Day, Year, Agenda) with no React 19 console errors.

### Changes

#### React 19 compatibility

| Area | Change |
|---|---|
| `@grafana/create-plugin` scaffolding | 7.0.8 → 7.6.0: migrations 009/010 fix `baseUrl` deprecation (TS6) and `ts-node` nodenext compat, resolving a build failure with `Option 'bundler' can only be used when 'module' is set to 'preserve' or to 'es2015' or later` |
| `react/jsx-runtime` externals | Added `react/jsx-runtime` and `react/jsx-dev-runtime` via `create-plugin add externalize-jsx-runtime` |
| `@types/testing-library__jest-dom` | Removed — replaced by `@testing-library/jest-dom` built-in types |

#### CI/CD

- Bumped `actions/create-github-app-token` v3.0.0 → v3.2.0
- Bumped `davelosert/vitest-coverage-report-action` v2.11.2 → v2.12.0

### `grafanaDependency`

Already `>=12.3.0` — no change required.

### Source code

No source code changes needed — plugin had no `ReactDOM.render`, `defaultProps`, `propTypes`,
`findDOMNode`, or other React 19 breaking patterns.

### Known Limitation: `react-overlays` / `findDOMNode`

`react-detect` flags `react-overlays@5.2.1` (bundled via `react-big-calendar`) for using
`ReactDOM.findDOMNode`, which is removed in React 19. The call is guarded:

```js
if (componentOrElement && 'setState' in componentOrElement) {
  return ReactDOM.findDOMNode(componentOrElement); // class components only
}
```

`react-big-calendar` uses function components throughout its public API, so this path is never
reached in practice — confirmed by zero `findDOMNode` errors in the React 19 smoke test.
A permanent fix requires an upstream release of `react-overlays` > 5.2.1.

### CI

`push.yml` already sets `run-playwright-with-skip-grafana-react-19-preview-image: false` —
CI tests against the React 19 preview Grafana image on every push.

## Local verification

Tested on Grafana 13.1.0 (`grafana-enterprise:dev-preview-react19`):

- Calendar renders with events on load
- All view switches (Month → Week → Day → Year → Agenda) work without error
- Day view navigation exercises `react-overlays` `Overlay` component — no crash
- Console: zero React 19 errors

## Test Plan

- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] All 205 unit tests pass (`npm run test:ci`)
- [x] CI fully green including `grafana-enterprise:dev-preview-react19`