### PR TITLE
ci: migrate stamp-changelog to GATB shared action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Generate GitHub App token
         id: app-token

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,24 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write
     steps:
-      - name: Get secrets from Vault
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
-        with:
-          vault_instance: ops
-          common_secrets: |
-            GITHUB_APP_ID=plugins-platform-bot-app:app-id
-            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:private-key
-          export_env: false
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
-          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          github_app: plugins-platform-bot-app
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.branch }}


### PR DESCRIPTION
## Summary

Replaces the two-step pattern of fetching Vault secrets then calling `actions/create-github-app-token` directly with the `grafana/shared-workflows/actions/create-github-app-token` shared action in the `stamp-changelog` job.

### CI/CD

- Remove `Get secrets from Vault` step (`grafana/shared-workflows/actions/get-vault-secrets`)
- Replace `actions/create-github-app-token` (direct, with Vault-fetched credentials) with
  `grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b`
  (`create-github-app-token/v0.2.3`) using `github_app: plugins-platform-bot-app`
- Remove `id-token: write` permission from `stamp-changelog` job (no longer needed without Vault OIDC)

Mirrors the pattern from grafana/plugin-ci-workflows@bc5feb7.