### PR TITLE
chore: stamp changelog for 4.2.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the **Business Calendar Panel** plugin for Grafana are do
 
 This changelog follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.2.4] - 2026-05-21
 
 ### Changed
 


### PR DESCRIPTION
Stamps the `[Unreleased]` section in `CHANGELOG.md` with version `4.2.4` and today's date, satisfying the pre-release check in the publish workflow.